### PR TITLE
Add new java/kotlin source factory APIs for better IDE experience

### DIFF
--- a/src/main/kotlin/com/tschuchort/compiletesting/SourceFile.kt
+++ b/src/main/kotlin/com/tschuchort/compiletesting/SourceFile.kt
@@ -2,6 +2,7 @@ package com.tschuchort.compiletesting
 
 import okio.buffer
 import okio.sink
+import org.intellij.lang.annotations.Language
 import java.io.File
 
 /**
@@ -11,6 +12,22 @@ abstract class SourceFile {
     internal abstract fun writeIfNeeded(dir: File): File
 
     companion object {
+        /**
+         * Create a new Java source file for the compilation when the compilation is run
+         */
+        fun java(name: String, @Language("java") contents: String, trimIndent: Boolean = true): SourceFile {
+            val finalContents = if (trimIndent) contents.trimIndent() else contents
+            return new(name, finalContents)
+        }
+
+        /**
+         * Create a new Kotlin source file for the compilation when the compilation is run
+         */
+        fun kotlin(name: String, @Language("kotlin") contents: String, trimIndent: Boolean = true): SourceFile {
+            val finalContents = if (trimIndent) contents.trimIndent() else contents
+            return new(name, finalContents)
+        }
+
         /**
          * Create a new source file for the compilation when the compilation is run
          */

--- a/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
+++ b/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
@@ -1,7 +1,7 @@
 package com.tschuchort.compiletesting
 
-import org.assertj.core.api.Assertions.assertThat
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Rule
 import org.junit.Test
@@ -20,7 +20,7 @@ class KotlinCompilationTests {
 	@Test
 	fun `runs with only kotlin sources`() {
 		val result = defaultCompilerConfig().apply {
-			sources = listOf(SourceFile.new("kSource.kt", "class KSource"))
+			sources = listOf(SourceFile.kotlin("kSource.kt", "class KSource"))
 		}.compile()
 
 		assertThat(result.exitCode).isEqualTo(ExitCode.OK)
@@ -30,7 +30,7 @@ class KotlinCompilationTests {
 	@Test
 	fun `runs with only java sources`() {
 		val result = defaultCompilerConfig().apply {
-			sources = listOf(SourceFile.new("JSource.java", "class JSource {}"))
+			sources = listOf(SourceFile.java("JSource.java", "class JSource {}"))
 		}.compile()
 
 		assertThat(result.exitCode).isEqualTo(ExitCode.OK)
@@ -85,7 +85,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Kotlin can access JDK`() {
-		val source = SourceFile.new("kSource.kt", """
+		val source = SourceFile.kotlin("kSource.kt", """
     |import javax.lang.model.SourceVersion
     |import java.io.File
     |
@@ -104,7 +104,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Kotlin can not access JDK`() {
-		val source = SourceFile.new("kSource.kt", """
+		val source = SourceFile.kotlin("kSource.kt", """
     |import javax.lang.model.SourceVersion
     |import java.io.File
     |
@@ -125,7 +125,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `can compile Kotlin without JDK`() {
-		val source = SourceFile.new("kSource.kt", "class KClass")
+		val source = SourceFile.kotlin("kSource.kt", "class KClass")
 
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(source)
@@ -138,7 +138,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Java can access JDK`() {
-		val source = SourceFile.new("JSource.java", """
+		val source = SourceFile.java("JSource.java", """
     |import javax.lang.model.SourceVersion;
     |import java.io.File;
     |
@@ -159,7 +159,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Java can not access JDK`() {
-		val source = SourceFile.new("JSource.java", """
+		val source = SourceFile.java("JSource.java", """
 		|import javax.lang.model.SourceVersion;
 		|import java.io.File;
 		|
@@ -181,7 +181,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Java inherits classpath`() {
-		val source = SourceFile.new("JSource.java", """
+		val source = SourceFile.java("JSource.java", """
     package com.tschuchort.compiletesting;
 
     class JSource {
@@ -202,7 +202,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Java doesn't inherit classpath`() {
-		val source = SourceFile.new("JSource.java", """
+		val source = SourceFile.java("JSource.java", """
     package com.tschuchort.compiletesting;
 
     class JSource {
@@ -223,7 +223,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Kotlin inherits classpath`() {
-		val source = SourceFile.new("KSource.kt", """
+		val source = SourceFile.kotlin("KSource.kt", """
     package com.tschuchort.compiletesting
 
     class KSource {
@@ -245,7 +245,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Kotlin doesn't inherit classpath`() {
-		val source = SourceFile.new("KSource.kt", """
+		val source = SourceFile.kotlin("KSource.kt", """
     package com.tschuchort.compiletesting
 
     class KSource {
@@ -267,7 +267,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Compiled Kotlin class can be loaded`() {
-		val source = SourceFile.new("Source.kt", """
+		val source = SourceFile.kotlin("Source.kt", """
     package com.tschuchort.compiletesting
 
     class Source {
@@ -301,7 +301,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Compiled Java class can be loaded`() {
-		val source = SourceFile.new("Source.java", """
+		val source = SourceFile.java("Source.java", """
     package com.tschuchort.compiletesting;
 
     public class Source {
@@ -330,7 +330,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Kotlin can access Java class`() {
-		val jSource = SourceFile.new("JSource.java", """
+		val jSource = SourceFile.java("JSource.java", """
     package com.tschuchort.compiletesting;
 
     class JSource {
@@ -338,7 +338,7 @@ class KotlinCompilationTests {
     }
 		""".trimIndent())
 
-		val kSource = SourceFile.new("KSource.kt", """
+		val kSource = SourceFile.kotlin("KSource.kt", """
     package com.tschuchort.compiletesting
 
     class KSource {
@@ -359,7 +359,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Java can access Kotlin class`() {
-		val jSource = SourceFile.new("JSource.java", """
+		val jSource = SourceFile.java("JSource.java", """
     package com.tschuchort.compiletesting;
 
     class JSource {
@@ -369,7 +369,7 @@ class KotlinCompilationTests {
     }
 		""".trimIndent())
 
-		val kSource = SourceFile.new("KSource.kt", """
+		val kSource = SourceFile.kotlin("KSource.kt", """
     package com.tschuchort.compiletesting
 
     class KSource {
@@ -388,7 +388,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Java AP sees Kotlin class`() {
-		val kSource = SourceFile.new(
+		val kSource = SourceFile.kotlin(
 			"KSource.kt", """
     package com.tschuchort.compiletesting
 
@@ -413,7 +413,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Java AP sees Java class`() {
-		val jSource = SourceFile.new(
+		val jSource = SourceFile.java(
 			"JSource.java", """
     package com.tschuchort.compiletesting;
 
@@ -438,7 +438,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Kotlin AP sees Kotlin class`() {
-		val kSource = SourceFile.new(
+		val kSource = SourceFile.kotlin(
 			"KSource.kt", """
     package com.tschuchort.compiletesting
 
@@ -465,7 +465,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Kotlin AP sees Java class`() {
-		val jSource = SourceFile.new(
+		val jSource = SourceFile.java(
 			"JSource.kt", """
     package com.tschuchort.compiletesting;
 
@@ -491,7 +491,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Given only Java sources, Kotlin sources are generated and compiled`() {
-		val jSource = SourceFile.new(
+		val jSource = SourceFile.java(
 			"JSource.java", """
     package com.tschuchort.compiletesting;
 
@@ -517,7 +517,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Java can access generated Kotlin class`() {
-		val jSource = SourceFile.new(
+		val jSource = SourceFile.java(
 			"JSource.java", """
     package com.tschuchort.compiletesting;
     import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_KOTLIN_CLASS_NAME};
@@ -544,7 +544,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Java can access generated Java class`() {
-		val jSource = SourceFile.new(
+		val jSource = SourceFile.java(
 			"JSource.java", """
     package com.tschuchort.compiletesting;
     import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_JAVA_CLASS_NAME};
@@ -571,7 +571,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Kotlin can access generated Kotlin class`() {
-		val kSource = SourceFile.new(
+		val kSource = SourceFile.kotlin(
 			"KSource.kt", """
     package com.tschuchort.compiletesting
     import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_KOTLIN_CLASS_NAME}
@@ -598,7 +598,7 @@ class KotlinCompilationTests {
 
 	@Test
 	fun `Kotlin can access generated Java class`() {
-		val kSource = SourceFile.new(
+		val kSource = SourceFile.kotlin(
 			"KSource.kt", """
     package com.tschuchort.compiletesting
     import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_JAVA_CLASS_NAME}

--- a/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
+++ b/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
@@ -86,13 +86,13 @@ class KotlinCompilationTests {
 	@Test
 	fun `Kotlin can access JDK`() {
 		val source = SourceFile.kotlin("kSource.kt", """
-    |import javax.lang.model.SourceVersion
-    |import java.io.File
-    |
-    |fun main(addKotlincArgs: Array<String>) {
-    |	File("")
-    |}
-			""".trimMargin())
+            import javax.lang.model.SourceVersion
+            import java.io.File
+            
+            fun main(addKotlincArgs: Array<String>) {
+            	File("")
+            }
+			""")
 
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(source)
@@ -105,13 +105,13 @@ class KotlinCompilationTests {
 	@Test
 	fun `Kotlin can not access JDK`() {
 		val source = SourceFile.kotlin("kSource.kt", """
-    |import javax.lang.model.SourceVersion
-    |import java.io.File
-    |
-    |fun main(addKotlincArgs: Array<String>) {
-    |	File("")
-    |}
-			""".trimMargin())
+            import javax.lang.model.SourceVersion
+            import java.io.File
+            
+            fun main(addKotlincArgs: Array<String>) {
+            	File("")
+            }
+			""")
 
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(source)
@@ -139,15 +139,15 @@ class KotlinCompilationTests {
 	@Test
 	fun `Java can access JDK`() {
 		val source = SourceFile.java("JSource.java", """
-    |import javax.lang.model.SourceVersion;
-    |import java.io.File;
-    |
-    |class JSource {
-    |	File foo() {
-    |		return new File("");
-    |	}
-    |}
-			""".trimMargin())
+            import javax.lang.model.SourceVersion;
+            import java.io.File;
+            
+            class JSource {
+            	File foo() {
+            		return new File("");
+            	}
+            }
+			""")
 
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(source)
@@ -160,15 +160,15 @@ class KotlinCompilationTests {
 	@Test
 	fun `Java can not access JDK`() {
 		val source = SourceFile.java("JSource.java", """
-		|import javax.lang.model.SourceVersion;
-		|import java.io.File;
-		|
-		|class JSource {
-		|	File foo() {
-		|		return new File("");
-		|	}
-		|}
-			""".trimMargin())
+		    import javax.lang.model.SourceVersion;
+		    import java.io.File;
+		    
+		    class JSource {
+		    	File foo() {
+		    		return new File("");
+		    	}
+		    }
+			""")
 
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(source)
@@ -182,14 +182,14 @@ class KotlinCompilationTests {
 	@Test
 	fun `Java inherits classpath`() {
 		val source = SourceFile.java("JSource.java", """
-    package com.tschuchort.compiletesting;
-
-    class JSource {
-    	void foo() {
-    		String s = KotlinCompilationTests.InheritedClass.class.getName();
-    	}
-    }
-    	""".trimIndent())
+			package com.tschuchort.compiletesting;
+		
+			class JSource {
+				void foo() {
+					String s = KotlinCompilationTests.InheritedClass.class.getName();
+				}
+			}
+				""")
 
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(source)
@@ -203,14 +203,14 @@ class KotlinCompilationTests {
 	@Test
 	fun `Java doesn't inherit classpath`() {
 		val source = SourceFile.java("JSource.java", """
-    package com.tschuchort.compiletesting;
-
-    class JSource {
-    	void foo() {
-    		String s = KotlinCompilationTests.InheritedClass.class.getName();
-    	}
-    }
-    	""".trimIndent())
+			package com.tschuchort.compiletesting;
+		
+			class JSource {
+				void foo() {
+					String s = KotlinCompilationTests.InheritedClass.class.getName();
+				}
+			}
+				""")
 
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(source)
@@ -224,14 +224,14 @@ class KotlinCompilationTests {
 	@Test
 	fun `Kotlin inherits classpath`() {
 		val source = SourceFile.kotlin("KSource.kt", """
-    package com.tschuchort.compiletesting
-
-    class KSource {
-    	fun foo() {
-    		val s = KotlinCompilationTests.InheritedClass::class.java.name
-    	}
-    }
-		""".trimIndent())
+			package com.tschuchort.compiletesting
+		
+			class KSource {
+				fun foo() {
+					val s = KotlinCompilationTests.InheritedClass::class.java.name
+				}
+			}
+				""")
 
 
 		val result = defaultCompilerConfig().apply {
@@ -246,14 +246,14 @@ class KotlinCompilationTests {
 	@Test
 	fun `Kotlin doesn't inherit classpath`() {
 		val source = SourceFile.kotlin("KSource.kt", """
-    package com.tschuchort.compiletesting
-
-    class KSource {
-    	fun foo() {
-    		val s = KotlinCompilationTests.InheritedClass::class.java.name
-    	}
-    }
-		""".trimIndent())
+			package com.tschuchort.compiletesting
+		
+			class KSource {
+				fun foo() {
+					val s = KotlinCompilationTests.InheritedClass::class.java.name
+				}
+			}
+				""")
 
 
 		val result = defaultCompilerConfig().apply {
@@ -268,14 +268,14 @@ class KotlinCompilationTests {
 	@Test
 	fun `Compiled Kotlin class can be loaded`() {
 		val source = SourceFile.kotlin("Source.kt", """
-    package com.tschuchort.compiletesting
-
-    class Source {
-    	fun helloWorld(): String {
-    		return "Hello World"
-    	}
-    }
-		""".trimIndent())
+			package com.tschuchort.compiletesting
+		
+			class Source {
+				fun helloWorld(): String {
+					return "Hello World"
+				}
+			}
+				""")
 
 
 		val result = defaultCompilerConfig().apply {
@@ -302,14 +302,14 @@ class KotlinCompilationTests {
 	@Test
 	fun `Compiled Java class can be loaded`() {
 		val source = SourceFile.java("Source.java", """
-    package com.tschuchort.compiletesting;
-
-    public class Source {
-    	public String helloWorld() {
-    		return "Hello World";
-    	}
-    }
-		""".trimIndent())
+			package com.tschuchort.compiletesting;
+		
+			public class Source {
+				public String helloWorld() {
+					return "Hello World";
+				}
+			}
+				""")
 
 
 		val result = defaultCompilerConfig().apply {
@@ -331,22 +331,22 @@ class KotlinCompilationTests {
 	@Test
 	fun `Kotlin can access Java class`() {
 		val jSource = SourceFile.java("JSource.java", """
-    package com.tschuchort.compiletesting;
+			package com.tschuchort.compiletesting;
+		
+			class JSource {
+				void foo() {}
+			}
+				""")
 
-    class JSource {
-    	void foo() {}
-    }
-		""".trimIndent())
-
-		val kSource = SourceFile.kotlin("KSource.kt", """
-    package com.tschuchort.compiletesting
-
-    class KSource {
-    	fun bar() {
-    		JSource().foo()
-    	}
-    }
-		""".trimIndent())
+				val kSource = SourceFile.kotlin("KSource.kt", """
+			package com.tschuchort.compiletesting
+		
+			class KSource {
+				fun bar() {
+					JSource().foo()
+				}
+			}
+				""")
 
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(kSource, jSource)
@@ -360,22 +360,22 @@ class KotlinCompilationTests {
 	@Test
 	fun `Java can access Kotlin class`() {
 		val jSource = SourceFile.java("JSource.java", """
-    package com.tschuchort.compiletesting;
+			package com.tschuchort.compiletesting;
+		
+			class JSource {
+				void foo() {
+					String s = (new KSource()).bar();
+				}
+			}
+				""")
 
-    class JSource {
-    	void foo() {
-    		String s = (new KSource()).bar();
-    	}
-    }
-		""".trimIndent())
-
-		val kSource = SourceFile.kotlin("KSource.kt", """
-    package com.tschuchort.compiletesting
-
-    class KSource {
-    	fun bar(): String = "bar"
-    }
-		""".trimIndent())
+				val kSource = SourceFile.kotlin("KSource.kt", """
+			package com.tschuchort.compiletesting
+		
+			class KSource {
+				fun bar(): String = "bar"
+			}
+				""")
 
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(kSource, jSource)
@@ -390,12 +390,12 @@ class KotlinCompilationTests {
 	fun `Java AP sees Kotlin class`() {
 		val kSource = SourceFile.kotlin(
 			"KSource.kt", """
-    package com.tschuchort.compiletesting
-
-	@ProcessElem
-    class KSource {
-    }
-		""".trimIndent())
+				package com.tschuchort.compiletesting
+			
+				@ProcessElem
+				class KSource {
+				}
+					""")
 
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(kSource)
@@ -415,12 +415,12 @@ class KotlinCompilationTests {
 	fun `Java AP sees Java class`() {
 		val jSource = SourceFile.java(
 			"JSource.java", """
-    package com.tschuchort.compiletesting;
-
-	@ProcessElem
-    class JSource {
-    }
-		""".trimIndent())
+				package com.tschuchort.compiletesting;
+			
+				@ProcessElem
+				class JSource {
+				}
+					""")
 
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(jSource)
@@ -440,12 +440,12 @@ class KotlinCompilationTests {
 	fun `Kotlin AP sees Kotlin class`() {
 		val kSource = SourceFile.kotlin(
 			"KSource.kt", """
-    package com.tschuchort.compiletesting
-
-	@ProcessElem
-    class KSource {
-    }
-		""".trimIndent()
+				package com.tschuchort.compiletesting
+			
+				@ProcessElem
+				class KSource {
+				}
+					"""
 		)
 
 		val result = defaultCompilerConfig().apply {
@@ -467,12 +467,12 @@ class KotlinCompilationTests {
 	fun `Kotlin AP sees Java class`() {
 		val jSource = SourceFile.java(
 			"JSource.kt", """
-    package com.tschuchort.compiletesting;
-
-	@ProcessElem
-    class JSource {
-    }
-		""".trimIndent()
+				package com.tschuchort.compiletesting;
+			
+				@ProcessElem
+				class JSource {
+				}
+					"""
 		)
 
 		val result = defaultCompilerConfig().apply {
@@ -493,12 +493,12 @@ class KotlinCompilationTests {
 	fun `Given only Java sources, Kotlin sources are generated and compiled`() {
 		val jSource = SourceFile.java(
 			"JSource.java", """
-    package com.tschuchort.compiletesting;
-
-	@ProcessElem
-    class JSource {
-    }
-		""".trimIndent()
+				package com.tschuchort.compiletesting;
+			
+				@ProcessElem
+				class JSource {
+				}
+					"""
 		)
 
 		val result = defaultCompilerConfig().apply {
@@ -519,16 +519,16 @@ class KotlinCompilationTests {
 	fun `Java can access generated Kotlin class`() {
 		val jSource = SourceFile.java(
 			"JSource.java", """
-    package com.tschuchort.compiletesting;
-    import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_KOTLIN_CLASS_NAME};
-
-	@ProcessElem
-    class JSource {
-    	void foo() {
-    		Class<?> c = ${KotlinTestProcessor.GENERATED_KOTLIN_CLASS_NAME}.class;
-		}
-    }
-		""".trimIndent()
+				package com.tschuchort.compiletesting;
+				import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_KOTLIN_CLASS_NAME};
+			
+				@ProcessElem
+				class JSource {
+					void foo() {
+						Class<?> c = ${KotlinTestProcessor.GENERATED_KOTLIN_CLASS_NAME}.class;
+					}
+				}
+					"""
 		)
 
 		val result = defaultCompilerConfig().apply {
@@ -546,16 +546,16 @@ class KotlinCompilationTests {
 	fun `Java can access generated Java class`() {
 		val jSource = SourceFile.java(
 			"JSource.java", """
-    package com.tschuchort.compiletesting;
-    import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_JAVA_CLASS_NAME};
-
-	@ProcessElem
-    class JSource {
-    	void foo() {
-    		Class<?> c = ${KotlinTestProcessor.GENERATED_JAVA_CLASS_NAME}.class;
-		}
-    }
-		""".trimIndent()
+				package com.tschuchort.compiletesting;
+				import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_JAVA_CLASS_NAME};
+			
+				@ProcessElem
+				class JSource {
+					void foo() {
+						Class<?> c = ${KotlinTestProcessor.GENERATED_JAVA_CLASS_NAME}.class;
+					}
+				}
+					"""
 		)
 
 		val result = defaultCompilerConfig().apply {
@@ -573,16 +573,16 @@ class KotlinCompilationTests {
 	fun `Kotlin can access generated Kotlin class`() {
 		val kSource = SourceFile.kotlin(
 			"KSource.kt", """
-    package com.tschuchort.compiletesting
-    import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_KOTLIN_CLASS_NAME}
-
-	@ProcessElem
-    class KSource {
-    	fun foo() {
-    		val c = ${KotlinTestProcessor.GENERATED_KOTLIN_CLASS_NAME}::class.java
-		}
-    }
-		""".trimIndent()
+				package com.tschuchort.compiletesting
+				import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_KOTLIN_CLASS_NAME}
+			
+				@ProcessElem
+				class KSource {
+					fun foo() {
+						val c = ${KotlinTestProcessor.GENERATED_KOTLIN_CLASS_NAME}::class.java
+					}
+				}
+					"""
 		)
 
 		val result = defaultCompilerConfig().apply {
@@ -600,16 +600,16 @@ class KotlinCompilationTests {
 	fun `Kotlin can access generated Java class`() {
 		val kSource = SourceFile.kotlin(
 			"KSource.kt", """
-    package com.tschuchort.compiletesting
-    import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_JAVA_CLASS_NAME}
-
-	@ProcessElem
-    class KSource {
-    	fun foo() {
-    		val c = ${KotlinTestProcessor.GENERATED_JAVA_CLASS_NAME}::class.java
-		}
-    }
-		""".trimIndent()
+				package com.tschuchort.compiletesting
+				import ${KotlinTestProcessor.GENERATED_PACKAGE}.${KotlinTestProcessor.GENERATED_JAVA_CLASS_NAME}
+			
+				@ProcessElem
+				class KSource {
+					fun foo() {
+						val c = ${KotlinTestProcessor.GENERATED_JAVA_CLASS_NAME}::class.java
+					}
+				}
+				"""
 		)
 
 		val result = defaultCompilerConfig().apply {


### PR DESCRIPTION
This adds new `SourceFile.kotlin` and `SourceFile.java` factory APIs intended to improve the IDE experience. 

These allow annotating the contents parameter with `@Language`, which in turn is great for consumers because IntelliJ will then apply syntax highlighting to these parameters. 

This also assumes they're already indented (which is necessary for the syntax highlighting), while allowing specification of is it needs to be treated as not already indented. This allows for the happy path of not needing to handle indented()/margin() calls on the end.

Example of how it looks now in the IDE:

![image](https://user-images.githubusercontent.com/1361086/65133453-a4092b00-d9d0-11e9-853f-c7ce6ab315c2.png)
