### PR TITLE
Update to Kotlin 1.3.60

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.60'
 
     repositories {
         mavenCentral()
@@ -15,7 +15,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.50'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.60'
 }
 
 apply plugin: 'kotlin'
@@ -56,12 +56,12 @@ dependencies {
 
     // This dependency is only needed as a "sample" compiler plugin to test that
     // running compiler plugins passed via the pluginClasspath CLI option works
-    testRuntime "org.jetbrains.kotlin:kotlin-scripting-compiler:1.3.50"
+    testRuntime "org.jetbrains.kotlin:kotlin-scripting-compiler:1.3.60"
 
     // The Kotlin compiler should be near the end of the list because its .jar file includes
     // an obsolete version of Guava
-    implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.50"
-    implementation "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable:1.3.50"
+    implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.60"
+    implementation "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable:1.3.60"
 }
 
 compileKotlin {

--- a/src/main/kotlin/com/tschuchort/compiletesting/KaptComponentRegistrar.kt
+++ b/src/main/kotlin/com/tschuchort/compiletesting/KaptComponentRegistrar.kt
@@ -49,9 +49,9 @@ import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 import org.jetbrains.kotlin.resolve.jvm.extensions.PartialAnalysisHandlerExtension
 import java.io.File
 
-internal class KaptComponentRegistrar @JvmOverloads constructor(
-    private val processors: List<IncrementalProcessor> = emptyList(),
-    private val kaptOptions: KaptOptions.Builder = KaptOptions.Builder()
+internal class KaptComponentRegistrar(
+    private val processors: List<IncrementalProcessor>,
+    private val kaptOptions: KaptOptions.Builder
 ) : ComponentRegistrar {
 
     override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {

--- a/src/main/kotlin/com/tschuchort/compiletesting/KaptComponentRegistrar.kt
+++ b/src/main/kotlin/com/tschuchort/compiletesting/KaptComponentRegistrar.kt
@@ -97,33 +97,9 @@ internal class KaptComponentRegistrar(
         }
 
         AnalysisHandlerExtension.registerExtension(project, kapt3AnalysisCompletedHandlerExtension)
-        StorageComponentContainerContributor.registerExtension(project,
-            Kapt3ComponentRegistrar.KaptComponentContributor(
-                object : PartialAnalysisHandlerExtension() {
-                    override val analyzePartially: Boolean
-                        get() = false
-
-                    override fun analysisCompleted(
-                        project: Project,
-                        module: ModuleDescriptor,
-                        bindingTrace: BindingTrace,
-                        files: Collection<KtFile>
-                    ): AnalysisResult? {
-                        return null
-                    }
-
-                    override fun doAnalysis(
-                        project: Project,
-                        module: ModuleDescriptor,
-                        projectContext: ProjectContext,
-                        files: Collection<KtFile>,
-                        bindingTrace: BindingTrace,
-                        componentProvider: ComponentProvider
-                    ): AnalysisResult? {
-                        return null
-                    }
-                }
-            )
+        StorageComponentContainerContributor.registerExtension(
+            project = project,
+            extension = Kapt3ComponentRegistrar.KaptComponentContributor(kapt3AnalysisCompletedHandlerExtension)
         )
     }
 

--- a/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
+++ b/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
@@ -628,7 +628,7 @@ class KotlinCompilationTests {
 	fun `detects the plugin provided for compilation via pluginClasspaths property`() {
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(SourceFile.kotlin("kSource.kt", "class KSource"))
-			pluginClasspaths = listOf(classpathOf("kotlin-scripting-compiler-1.3.50"))
+			pluginClasspaths = listOf(classpathOf("kotlin-scripting-compiler-1.3.60"))
 		}.compile()
 
 		assertThat(result.exitCode).isEqualTo(ExitCode.OK)


### PR DESCRIPTION
Note that since this is using private APIs of kotlin, it's not possible to support older versions simultaneously since it's not possible to detect what version of the tools you're consuming are without some very uncomfortable reflection.

Resolves #30 