### PR TITLE
Bump to Kotlin 1.3.70

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Add dependency to your module's `build.gradle` file:
 ```Groovy
 dependencies {
         // ...
-	implementation 'com.github.tschuchortdev:kotlin-compile-testing:1.2.6'
+	implementation 'com.github.tschuchortdev:kotlin-compile-testing:1.2.7'
 }
 ```
 
@@ -109,7 +109,7 @@ Kotlin-Compile-Testing is compatible with all _local_ compiler versions. It does
 
 However, if your project or any of its dependencies depend directly on compiler artifacts such as `kotlin-compiler-embeddable` or `kotlin-annotation-processing-embeddable` then they have to be the same version as the one used by Kotlin-Compile-Testing or there will be a transitive dependency conflict.
 
-- Current `kotlin-compiler-embeddable` version: `1.3.61`
+- Current `kotlin-compiler-embeddable` version: `1.3.70`
 
 Because the internal APIs of the Kotlin compiler often change between versions, we can only support one `kotlin-compiler-embeddable` version at a time. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.3.70'
 
     repositories {
         mavenCentral()
@@ -15,7 +15,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.61'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.70'
 }
 
 apply plugin: 'kotlin'
@@ -59,12 +59,12 @@ dependencies {
 
     // This dependency is only needed as a "sample" compiler plugin to test that
     // running compiler plugins passed via the pluginClasspath CLI option works
-    testRuntime "org.jetbrains.kotlin:kotlin-scripting-compiler:1.3.61"
+    testRuntime "org.jetbrains.kotlin:kotlin-scripting-compiler:1.3.70"
 
     // The Kotlin compiler should be near the end of the list because its .jar file includes
     // an obsolete version of Guava
-    implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.61"
-    implementation "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable:1.3.61"
+    implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.70"
+    implementation "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable:1.3.70"
 }
 
 compileKotlin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.incremental=false
 
 GROUP=com.github.tschuchortdev
-VERSION_NAME=1.2.6
+VERSION_NAME=1.2.7
 POM_DESCRIPTION=A library that enables testing of Kotlin annotation processors, compiler plugins and code generation.
 POM_INCEPTION_YEAR=2019
 POM_URL=https://github.com/tschuchortdev/kotlin-compile-testing

--- a/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -38,6 +38,7 @@ import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.Services
 import org.jetbrains.kotlin.kapt3.base.incremental.DeclaredProcType
 import org.jetbrains.kotlin.kapt3.base.incremental.IncrementalProcessor
+import org.jetbrains.kotlin.kapt3.util.MessageCollectorBackedKaptLogger
 import java.io.*
 import java.lang.RuntimeException
 import java.net.URI
@@ -509,6 +510,8 @@ class KotlinCompilation {
 				it.flags.addAll(KaptFlag.MAP_DIAGNOSTIC_LOCATIONS, KaptFlag.VERBOSE)
 		}
 
+		val kaptLogger = MessageCollectorBackedKaptLogger(kaptOptions.build())
+
 		/** The main compiler plugin (MainComponentRegistrar)
 		 *  is instantiated by K2JVMCompiler using
 		 *  a service locator. So we can't just pass parameters to it easily.
@@ -518,7 +521,7 @@ class KotlinCompilation {
 		 */
 		MainComponentRegistrar.threadLocalParameters.set(
 				MainComponentRegistrar.ThreadLocalParameters(
-					annotationProcessors.map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL) },
+					annotationProcessors.map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL, kaptLogger) },
 					kaptOptions,
 					compilerPlugins
 				)

--- a/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -510,7 +510,11 @@ class KotlinCompilation {
 				it.flags.addAll(KaptFlag.MAP_DIAGNOSTIC_LOCATIONS, KaptFlag.VERBOSE)
 		}
 
-		val kaptLogger = MessageCollectorBackedKaptLogger(kaptOptions.build())
+		val compilerMessageCollector = PrintingMessageCollector(
+			internalMessageStream, MessageRenderer.GRADLE_STYLE, verbose
+		)
+
+		val kaptLogger = MessageCollectorBackedKaptLogger(kaptOptions.build(), compilerMessageCollector)
 
 		/** The main compiler plugin (MainComponentRegistrar)
 		 *  is instantiated by K2JVMCompiler using
@@ -570,10 +574,6 @@ class KotlinCompilation {
 			it.freeArgs = sourcePaths
 			it.pluginClasspaths = (it.pluginClasspaths ?: emptyArray()) + arrayOf(getResourcesPath())
 		}
-
-		val compilerMessageCollector = PrintingMessageCollector(
-			internalMessageStream, MessageRenderer.GRADLE_STYLE, verbose
-		)
 
 		return convertKotlinExitCode(
             K2JVMCompiler().exec(compilerMessageCollector, Services.EMPTY, k2JvmArgs)

--- a/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
+++ b/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
@@ -632,7 +632,7 @@ class KotlinCompilationTests {
 	fun `detects the plugin provided for compilation via pluginClasspaths property`() {
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(SourceFile.kotlin("kSource.kt", "class KSource"))
-			pluginClasspaths = listOf(classpathOf("kotlin-scripting-compiler-1.3.61"))
+			pluginClasspaths = listOf(classpathOf("kotlin-scripting-compiler-1.3.70"))
 		}.compile()
 
 		assertThat(result.exitCode).isEqualTo(ExitCode.OK)


### PR DESCRIPTION
This adds support for Kotlin 1.3.70. The major change was a breaking API in IncrementalProcessor that needed an additional logger passed in. The logger used is also used in the kotlin lang tests for kapt. However, an alternative would be to implement the interface for KaptLogger within the project. This *seems* fine though.

Compiles and tests successfully.

Resolves #38