### PR TITLE
Replacing matchEntire with find in Regex

### DIFF
--- a/src/main/kotlin/com/tschuchort/compiletesting/JavacUtils.kt
+++ b/src/main/kotlin/com/tschuchort/compiletesting/JavacUtils.kt
@@ -75,10 +75,14 @@ internal fun getJavacVersionString(javacCommand: String): String {
 
     val output = buffer.readUtf8()
 
-    return Regex("javac (.*)?[\\s\\S]*").matchEntire(output)?.destructured?.component1()
-        ?: throw IllegalStateException("Command '$javacCommand -version' did not print expected output. " +
-                "Output was: '$output'")
+    return parseVersionString(output) ?: throw IllegalStateException(
+        "Command '$javacCommand -version' did not print expected output. " +
+                "Output was: '$output'"
+    )
 }
+
+internal fun parseVersionString(output: String) =
+    Regex("javac (.*)?[\\s\\S]*").find(output)?.destructured?.component1()
 
 internal fun isJavac9OrLater(javacVersionString: String): Boolean {
     try {

--- a/src/test/kotlin/com/tschuchort/compiletesting/JavacUtilsTest.kt
+++ b/src/test/kotlin/com/tschuchort/compiletesting/JavacUtilsTest.kt
@@ -1,7 +1,6 @@
 package com.tschuchort.compiletesting
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Test
 
 class JavacUtilsTest {
@@ -38,5 +37,29 @@ class JavacUtilsTest {
     @Test
     fun `Old version scheme with extra info is parsed correctly`() {
         assertTrue(isJavac9OrLater("1.11.0-bla"))
+    }
+
+    @Test
+    fun `Standard javac -version output is parsed correctly`() {
+        assertEquals("1.8.0_252", parseVersionString("javac 1.8.0_252"))
+    }
+
+    @Test
+    fun `javac -version output with JAVA OPTIONS is parsed correctly`() {
+        assertEquals(
+            "1.8.0_222",
+            parseVersionString(
+                "Picked up _JAVA_OPTIONS: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap javac 1.8.0_222"
+            )
+        )
+    }
+
+    @Test
+    fun `Wrong javac -version output is returning null`() {
+        assertNull(
+            parseVersionString(
+                "wrong javac"
+            )
+        )
     }
 }


### PR DESCRIPTION
****Reason****
Our CI build server happen to return `Picked up JAVA_OPTIONS: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
javac 1.8.0_222` for `javac -version`, which `matchEntire` doesn't match.

Let me know if I should add tests :)