### PR TITLE
Fix regex to support kotlin 1.4

### DIFF
--- a/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -251,7 +251,7 @@ class KotlinCompilation {
 	 */
 	var kotlinStdLibJar: File? by default {
 		findInHostClasspath(hostClasspaths, "kotlin-stdlib.jar",
-			Regex("(kotlin-stdlib|kotlin-runtime)(-[0-9]+\\.[0-9]+\\.[0-9]+)([-0-9a-zA-Z]+)?\\.jar"))
+			kotlinDependencyRegex("(kotlin-stdlib|kotlin-runtime)"))
 	}
 
 	/**
@@ -261,7 +261,7 @@ class KotlinCompilation {
 	 */
 	var kotlinStdLibJdkJar: File? by default {
 		findInHostClasspath(hostClasspaths, "kotlin-stdlib-jdk*.jar",
-			Regex("kotlin-stdlib-jdk[0-9]+(-[0-9]+\\.[0-9]+\\.[0-9]+)([-0-9a-zA-Z]+)?\\.jar"))
+			kotlinDependencyRegex("kotlin-stdlib-jdk[0-9]+"))
 	}
 
 	/**
@@ -271,7 +271,7 @@ class KotlinCompilation {
 	 */
 	var kotlinReflectJar: File? by default {
 		findInHostClasspath(hostClasspaths, "kotlin-reflect.jar",
-			Regex("kotlin-reflect(-[0-9]+\\.[0-9]+\\.[0-9]+)([-0-9a-zA-Z]+)?\\.jar"))
+			kotlinDependencyRegex("kotlin-reflect"))
 	}
 
 	/**
@@ -281,7 +281,7 @@ class KotlinCompilation {
 	 */
 	var kotlinScriptRuntimeJar: File? by default {
 		findInHostClasspath(hostClasspaths, "kotlin-script-runtime.jar",
-			Regex("kotlin-script-runtime(-[0-9]+\\.[0-9]+\\.[0-9]+)([-0-9a-zA-Z]+)?\\.jar"))
+			kotlinDependencyRegex("kotlin-script-runtime"))
 	}
 
 	/**
@@ -291,7 +291,7 @@ class KotlinCompilation {
 	 */
 	var kotlinStdLibCommonJar: File? by default {
 		findInHostClasspath(hostClasspaths, "kotlin-stdlib-common.jar",
-			Regex("kotlin-stdlib-common(-[0-9]+\\.[0-9]+\\.[0-9]+)([-0-9a-zA-Z]+)?\\.jar"))
+			kotlinDependencyRegex("kotlin-stdlib-common"))
 	}
 
 	/**
@@ -904,6 +904,10 @@ class KotlinCompilation {
 	companion object {
 		const val OPTION_KAPT_KOTLIN_GENERATED = "kapt.kotlin.generated"
     }
+}
+
+private fun kotlinDependencyRegex(prefix:String): Regex {
+	return Regex("$prefix(-[0-9]+\\.[0-9]+(\\.[0-9]+)?)([-0-9a-zA-Z]+)?\\.jar")
 }
 
 private fun convertKotlinExitCode(code: ExitCode) = when(code) {


### PR DESCRIPTION
The Regex used to match kotlin runtime libraries required
version to have 3 numbers which broke with 1.4 milestore
releases since they have versions like 1.4-M1.

This PR updates the regex to make the PATCH version optional.

Since the regex was mostly duplicated, I moved it to a helper.