### PR TITLE
Setup publishing for the KSP artifact

### DIFF
--- a/ksp/build.gradle
+++ b/ksp/build.gradle
@@ -43,7 +43,7 @@ repositories {
 dependencies {
     // We do not specify a version here because `kotlin-compile-testing` is an included build and gradle will use the
     // main module of the main project as the dependency.
-    api("com.github.tschuchortdev:kotlin-compile-testing")
+    api("com.github.tschuchortdev:kotlin-compile-testing:$VERSION_NAME")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation "org.jetbrains.kotlin:kotlin-symbol-processing-api:$ksp_version"
     implementation "org.jetbrains.kotlin:kotlin-ksp:$ksp_version"

--- a/ksp/gradle.properties
+++ b/ksp/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=kotlin-compile-testing-ksp
+


### PR DESCRIPTION
This PR adds an ARTIFACT_ID to the KSP module so that it won't use
the same name as the main artifact.

I've also changed it to declare dependency on the main module with
the version name so that the generated POM does have the version.