### PR TITLE
support ksp 20200731 release

### DIFF
--- a/ksp/build.gradle
+++ b/ksp/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.4-M1'
-    ext.ksp_version='1.4-M1-dev-experimental-20200716'
+    ext.kotlin_version = '1.4.0-rc'
+    ext.ksp_version='1.4.0-rc-dev-experimental-20200731'
     // copy properties from the main project's properties file
     def mainProjectProperties = new File(
             gradle.includedBuild("kotlin-compile-testing").projectDir,

--- a/ksp/src/test/kotlin/com/tschuchort/compiletesting/AbstractTestSymbolProcessor.kt
+++ b/ksp/src/test/kotlin/com/tschuchort/compiletesting/AbstractTestSymbolProcessor.kt
@@ -1,6 +1,7 @@
 package com.tschuchort.compiletesting
 
 import org.jetbrains.kotlin.ksp.processing.CodeGenerator
+import org.jetbrains.kotlin.ksp.processing.KSPLogger
 import org.jetbrains.kotlin.ksp.processing.Resolver
 import org.jetbrains.kotlin.ksp.processing.SymbolProcessor
 
@@ -12,7 +13,7 @@ internal open class AbstractTestSymbolProcessor : SymbolProcessor {
     override fun finish() {
     }
 
-    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator) {
+    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
         this.codeGenerator = codeGenerator
     }
 

--- a/ksp/src/test/kotlin/com/tschuchort/compiletesting/KspTest.kt
+++ b/ksp/src/test/kotlin/com/tschuchort/compiletesting/KspTest.kt
@@ -38,7 +38,7 @@ class KspTest {
         }.compile()
         assertThat(result.exitCode).isEqualTo(ExitCode.OK)
         instance.inOrder {
-            verify().init(any(), any(), any())
+            verify().init(any(), any(), any(), any())
             verify().process(any())
             verify().finish()
         }
@@ -140,7 +140,7 @@ class KspTest {
             it.isFile
         }.toList()
         assertThat(generatedSources).containsExactly(
-            compilation.kspSourcesDir.resolve("generated/Gen.kt")
+            compilation.kspSourcesDir.resolve("kotlin/generated/Gen.kt")
         )
     }
 


### PR DESCRIPTION
There are 2 breaking changes with [20200731](https://github.com/android/kotlin/releases/tag/1.4.0-rc-dev-experimental-20200731) release:
* Output directory was reorganized to be more complying with Gradle convention.
* Added a logger for KSP processors.

For the logger, in current model for KSP tests, it looks to be not easy to obtain the same output stream as KotlinCompilation, therefore using System.err and left a TODO.