### PR TITLE
Report java sources to KSP

### DIFF
--- a/ksp/build.gradle
+++ b/ksp/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.ksp_version='1.4.20-dev-experimental-20210107'
+    ext.ksp_version='1.4.20-dev-experimental-20210111'
 }
 
 dependencies {

--- a/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
+++ b/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
@@ -8,8 +8,10 @@ import com.google.devtools.ksp.KspOptions
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.impl.MessageCollectorBasedKSPLogger
+import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
+import org.jetbrains.kotlin.cli.jvm.config.JavaSourceRoot
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.config.CompilerConfiguration
@@ -159,6 +161,12 @@ private class KspCompileTestingComponentRegistrar(
                 it.deleteRecursively()
                 it.mkdirs()
             }
+            configuration[CLIConfigurationKeys.CONTENT_ROOTS]
+                ?.filterIsInstance<JavaSourceRoot>()
+                ?.forEach {
+                    this.javaSourceRoots.add(it.file)
+                }
+
         }.build()
 
         // Temporary until friend-paths is fully supported https://youtrack.jetbrains.com/issue/KT-34102

--- a/ksp/src/test/kotlin/com/tschuchort/compiletesting/KspTest.kt
+++ b/ksp/src/test/kotlin/com/tschuchort/compiletesting/KspTest.kt
@@ -160,7 +160,7 @@ class KspTest {
     }
 
     @Test
-    fun canFindSymbols() {
+    fun findSymbols() {
         val javaSource = SourceFile.java(
             "JavaSubject.java",
             """
@@ -176,14 +176,14 @@ class KspTest {
             """.trimIndent()
         )
         val result = mutableListOf<String>()
-        val processor = object: AbstractTestSymbolProcessor() {
+        val processor = object : AbstractTestSymbolProcessor() {
             override fun process(resolver: Resolver) {
                 resolver.getSymbolsWithAnnotation(
                     SuppressWarnings::class.java.canonicalName
                 ).filterIsInstance<KSClassDeclaration>()
-                    .forEach{
-                    result.add(it.qualifiedName!!.asString())
-                }
+                    .forEach {
+                        result.add(it.qualifiedName!!.asString())
+                    }
             }
         }
         val compilation = KotlinCompilation().apply {
@@ -191,7 +191,7 @@ class KspTest {
             symbolProcessors += processor
         }
         compilation.compile()
-        assertThat(result).containsExactly(
+        assertThat(result).containsExactlyInAnyOrder(
             "JavaSubject", "KotlinSubject"
         )
     }


### PR DESCRIPTION
This PR fixes a bug where we were not reporting java sources when building ksp arguments. 
Failing to add them means `getSymbolsAnnotatedWith` misses all java sources.

I've also updated KSP to `1.4.20-dev-experimental-20210111`