### PR TITLE
Update KSP to 1.4.30-1.0.0-alpha02 and Kotlin to 1.4.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Kotlin-Compile-Testing is compatible with all _local_ compiler versions. It does
 
 However, if your project or any of its dependencies depend directly on compiler artifacts such as `kotlin-compiler-embeddable` or `kotlin-annotation-processing-embeddable` then they have to be the same version as the one used by Kotlin-Compile-Testing or there will be a transitive dependency conflict.
 
-- Current `kotlin-compiler-embeddable` version: `1.4.21-2`
+- Current `kotlin-compiler-embeddable` version: `1.4.30`
 
 Because the internal APIs of the Kotlin compiler often change between versions, we can only support one `kotlin-compiler-embeddable` version at a time. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.21-2'
+    ext.kotlin_version = '1.4.30'
 
     repositories {
         mavenCentral()

--- a/ksp/build.gradle
+++ b/ksp/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.ksp_version='1.4.20-dev-experimental-20210120'
+    ext.ksp_version='1.4.30-1.0.0-alpha02'
 }
 
 dependencies {

--- a/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
+++ b/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
@@ -102,14 +102,16 @@ private val KotlinCompilation.kspCachesDir: File
  */
 private class KspTestExtension(
     options: KspOptions,
-    private val processors: List<SymbolProcessor>,
+    processors: List<SymbolProcessor>,
     logger: KSPLogger
 ) : AbstractKotlinSymbolProcessingExtension(
     options = options,
     logger = logger,
     testMode = false
 ) {
-    override fun loadProcessors() = processors
+    private val loadedProcessors = processors
+
+    override fun loadProcessors() = loadedProcessors
 }
 
 /**

--- a/ksp/src/test/kotlin/com/tschuchort/compiletesting/AbstractTestSymbolProcessor.kt
+++ b/ksp/src/test/kotlin/com/tschuchort/compiletesting/AbstractTestSymbolProcessor.kt
@@ -4,6 +4,7 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.KSAnnotated
 
 /**
  * Helper class to write tests, only used in Ksp Compile Testing tests, not a public API.
@@ -19,6 +20,7 @@ internal open class AbstractTestSymbolProcessor : SymbolProcessor {
         this.logger = logger
     }
 
-    override fun process(resolver: Resolver) {
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        return emptyList()
     }
 }

--- a/ksp/src/test/kotlin/com/tschuchort/compiletesting/KspTest.kt
+++ b/ksp/src/test/kotlin/com/tschuchort/compiletesting/KspTest.kt
@@ -3,6 +3,7 @@ package com.tschuchort.compiletesting
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.inOrder
@@ -67,7 +68,7 @@ class KspTest {
         """.trimIndent()
         )
         val processor = object : AbstractTestSymbolProcessor() {
-            override fun process(resolver: Resolver) {
+            override fun process(resolver: Resolver): List<KSAnnotated> {
                 val symbols = resolver.getSymbolsWithAnnotation("foo.bar.TestAnnotation")
                 assertThat(symbols.size).isEqualTo(1)
                 val klass = symbols.first()
@@ -85,6 +86,7 @@ class KspTest {
                         class $genClassName() {}
                     """.trimIndent())
                 }
+                return emptyList()
             }
         }
         val result = KotlinCompilation().apply {
@@ -177,13 +179,14 @@ class KspTest {
         )
         val result = mutableListOf<String>()
         val processor = object : AbstractTestSymbolProcessor() {
-            override fun process(resolver: Resolver) {
+            override fun process(resolver: Resolver): List<KSAnnotated> {
                 resolver.getSymbolsWithAnnotation(
                     SuppressWarnings::class.java.canonicalName
                 ).filterIsInstance<KSClassDeclaration>()
                     .forEach {
                         result.add(it.qualifiedName!!.asString())
                     }
+                return emptyList()
             }
         }
         val compilation = KotlinCompilation().apply {
@@ -200,7 +203,7 @@ class KspTest {
         private val packageName: String,
         private val className: String
     ) : AbstractTestSymbolProcessor() {
-        override fun process(resolver: Resolver) {
+        override fun process(resolver: Resolver): List<KSAnnotated> {
             super.process(resolver)
             codeGenerator.createNewFile(
                 dependencies = Dependencies.ALL_FILES,
@@ -212,6 +215,7 @@ class KspTest {
                     class $className() {}
                     """.trimIndent())
             }
+            return emptyList()
         }
     }
 
@@ -231,12 +235,13 @@ class KspTest {
         """.trimIndent()
         )
         val processor = object : AbstractTestSymbolProcessor() {
-            override fun process(resolver: Resolver) {
+            override fun process(resolver: Resolver): List<KSAnnotated> {
                 logger.logging("This is a log message")
                 logger.info("This is an info message")
                 logger.warn("This is an warn message")
                 logger.error("This is an error message")
                 logger.exception(Throwable("This is a failure"))
+                return emptyList()
             }
         }
         val result = KotlinCompilation().apply {


### PR DESCRIPTION
This includes some fixes to tests that would otherwise end up in an infinite loop with its new multiple rounds behavior.