### PR TITLE
Cache host classpath

### DIFF
--- a/core/src/main/kotlin/com/tschuchort/compiletesting/HostEnvironment.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/HostEnvironment.kt
@@ -1,0 +1,66 @@
+package com.tschuchort.compiletesting
+
+import io.github.classgraph.ClassGraph
+import java.io.File
+
+/**
+ * Utility object to provide everything we might discover from the host environment.
+ */
+internal object HostEnvironment {
+    val classpath by lazy {
+        getHostClasspaths()
+    }
+
+    val kotlinStdLibJar: File? by lazy {
+        findInClasspath(kotlinDependencyRegex("(kotlin-stdlib|kotlin-runtime)"))
+    }
+
+    val kotlinStdLibCommonJar: File? by lazy {
+        findInClasspath(kotlinDependencyRegex("kotlin-stdlib-common"))
+    }
+
+    val kotlinStdLibJdkJar: File? by lazy {
+        findInClasspath(kotlinDependencyRegex("kotlin-stdlib-jdk[0-9]+"))
+    }
+
+    val kotlinStdLibJsJar: File? by default {
+        findInClasspath(kotlinDependencyRegex("kotlin-stdlib-js"))
+    }
+
+    val kotlinReflectJar: File? by lazy {
+        findInClasspath(kotlinDependencyRegex("kotlin-reflect"))
+    }
+
+    val kotlinScriptRuntimeJar: File? by lazy {
+        findInClasspath(kotlinDependencyRegex("kotlin-script-runtime"))
+    }
+
+    val toolsJar: File? by lazy {
+        findInClasspath(Regex("tools.jar"))
+    }
+
+    private fun kotlinDependencyRegex(prefix: String): Regex {
+        return Regex("$prefix(-[0-9]+\\.[0-9]+(\\.[0-9]+)?)([-0-9a-zA-Z]+)?\\.jar")
+    }
+
+    /** Tries to find a file matching the given [regex] in the host process' classpath */
+    private fun findInClasspath(regex: Regex): File? {
+        val jarFile = classpath.firstOrNull { classpath ->
+            classpath.name.matches(regex)
+            //TODO("check that jar file actually contains the right classes")
+        }
+        return jarFile
+    }
+
+    /** Returns the files on the classloader's classpath and modulepath */
+    private fun getHostClasspaths(): List<File> {
+        val classGraph = ClassGraph()
+            .enableSystemJarsAndModules()
+            .removeTemporaryFilesAfterScan()
+
+        val classpaths = classGraph.classpathFiles
+        val modules = classGraph.modules.mapNotNull { it.locationFile }
+
+        return (classpaths + modules).distinctBy(File::getAbsolutePath)
+    }
+}

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -178,8 +178,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	 * process' classpaths
 	 */
 	var kotlinStdLibJar: File? by default {
-		findInHostClasspath(hostClasspaths, "kotlin-stdlib.jar",
-			kotlinDependencyRegex("(kotlin-stdlib|kotlin-runtime)"))
+		HostEnvironment.kotlinStdLibJar
 	}
 
 	/**
@@ -188,8 +187,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	 * process' classpaths
 	 */
 	var kotlinStdLibJdkJar: File? by default {
-		findInHostClasspath(hostClasspaths, "kotlin-stdlib-jdk*.jar",
-			kotlinDependencyRegex("kotlin-stdlib-jdk[0-9]+"))
+		HostEnvironment.kotlinStdLibJdkJar
 	}
 
 	/**
@@ -198,8 +196,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	 * process' classpaths
 	 */
 	var kotlinReflectJar: File? by default {
-		findInHostClasspath(hostClasspaths, "kotlin-reflect.jar",
-			kotlinDependencyRegex("kotlin-reflect"))
+		HostEnvironment.kotlinReflectJar
 	}
 
 	/**
@@ -208,8 +205,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	 * process' classpaths
 	 */
 	var kotlinScriptRuntimeJar: File? by default {
-		findInHostClasspath(hostClasspaths, "kotlin-script-runtime.jar",
-			kotlinDependencyRegex("kotlin-script-runtime"))
+		HostEnvironment.kotlinScriptRuntimeJar
 	}
 
 	/**
@@ -221,7 +217,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	var toolsJar: File? by default {
         if (!isJdk9OrLater())
             jdkHome?.let { findToolsJarFromJdk(it) }
-            ?: findInHostClasspath(hostClasspaths, "tools.jar", Regex("tools.jar"))
+            ?: HostEnvironment.toolsJar
         else
             null
 	}

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinJsCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinJsCompilation.kt
@@ -42,8 +42,7 @@ class KotlinJsCompilation : AbstractKotlinCompilation<K2JSCompilerArguments>() {
    * process' classpaths
    */
   var kotlinStdLibJsJar: File? by default {
-    findInHostClasspath(hostClasspaths, "kotlin-stdlib-js.jar",
-      kotlinDependencyRegex("kotlin-stdlib-js"))
+    HostEnvironment.kotlinStdLibJsJar
   }
 
   // *.class files, Jars and resources (non-temporary) that are created by the


### PR DESCRIPTION
This PR adds caching for host classpath to avoid calling ClassGraph for
every compilation. In my local tests, it saves between 50 to 80ms per
compilation on my laptop, which is not necessarily much but adds up when
you run hundreds of them.

I've also cached common jars we find from there. It does not necessarily
help with performance but rather as a cleanup to keep all of them in 1
place.

Test: existing tests
Issue: #113