### PR TITLE
Use in process java compilation unless jdk is explicitly set by the d…

### DIFF
--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -506,7 +506,10 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
         if(jdkHome != null && jdkHome!!.canonicalPath != processJdkHome.canonicalPath) {
             /* If a JDK home is given, try to run javac from there so it uses the same JDK
                as K2JVMCompiler. Changing the JDK of the system java compiler via the
-               "--system" and "-bootclasspath" options is not so easy. */
+               "--system" and "-bootclasspath" options is not so easy.
+               If the jdkHome is the same as the current process, we still run an in process compilation because it is
+               expensive to fork a process to compile.
+               */
             log("compiling java in a sub-process because a jdkHome is specified")
             val jdkBinFile = File(jdkHome, "bin")
             check(jdkBinFile.exists()) { "No JDK bin folder found at: ${jdkBinFile.toPath()}" }
@@ -539,7 +542,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 			val isJavac9OrLater = isJdk9OrLater()
 			val javacArgs = baseJavacArgs(isJavac9OrLater).apply {
 				if (jdkHome == null) {
-				    log("jdkHome is set to null, removing booth classpath from java compilation")
+				    log("jdkHome is set to null, removing boot classpath from java compilation")
 					// erase bootclasspath or JDK path because no JDK was specified
 					if (isJavac9OrLater)
 						addAll("--system", "none")

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/Utils.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/Utils.kt
@@ -19,11 +19,12 @@ internal fun getJavaHome(): File {
     return File(path).also { check(it.isDirectory) }
 }
 
-internal fun getJdkHome()
-    = if(isJdk9OrLater())
+internal val processJdkHome by lazy {
+    if(isJdk9OrLater())
         getJavaHome()
     else
         getJavaHome().parentFile
+}
 
 /** Checks if the JDK of the host process is version 9 or later */
 internal fun isJdk9OrLater(): Boolean

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
@@ -184,7 +184,7 @@ class KotlinCompilationTests {
 		assertThat(result.exitCode).isEqualTo(ExitCode.COMPILATION_ERROR)
 		assertThat(result.messages).contains("Unable to find package java.lang")
 		assertThat(result.messages).contains(
-			"jdkHome is set to null, removing booth classpath from java compilation"
+			"jdkHome is set to null, removing boot classpath from java compilation"
 		)
 	}
 
@@ -826,7 +826,7 @@ class KotlinCompilationTests {
 			"jdkHome is not specified. Using system java compiler of the host process."
 		)
 		assertThat(result.messages).doesNotContain(
-			"jdkHome is set to null, removing booth classpath from java compilation"
+			"jdkHome is set to null, removing boot classpath from java compilation"
 		)
 	}
 
@@ -855,7 +855,7 @@ class KotlinCompilationTests {
 			"compiling java in a sub-process because a jdkHome is specified"
 		)
 		assertThat(logs).doesNotContain(
-			"jdkHome is set to null, removing booth classpath from java compilation"
+			"jdkHome is set to null, removing boot classpath from java compilation"
 		)
 	}
 	

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
@@ -850,7 +850,7 @@ class KotlinCompilationTests {
 		}
 		// it should fail since we are passing a fake jdk
 		assertThat(compilation.isFailure).isTrue()
-		val logs = logsStream.toString(Charsets.UTF_8)
+		val logs = logsStream.toString("utf-8")// use string charset for jdk 8 compatibility
 		assertThat(logs).contains(
 			"compiling java in a sub-process because a jdkHome is specified"
 		)


### PR DESCRIPTION
This PR updates KCT to use in process compilation unless the developer
explicitly provides a jdkHome that does not match the java home of the
current process.

In most cases, it won't be provided and because we have a default,
current implementation makes KCT spin off another process to compile java
sources, causing a significant compilation time penalty.
https://github.com/tschuchortdev/kotlin-compile-testing/issues/113#issuecomment-781731252

With this change, KCT won't create another process unless jdkHome is
set to a value that does not match the jdk home inherited from the
current process.

Issue: #113
Test: As this is a bit difficult to test, I've added test that will
check the logs ¯\_(ツ)_/¯