### PR TITLE
Expose a property that allows to enable the old JVM backend.

### DIFF
--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -70,6 +70,9 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	/** Use the IR backend */
 	var useIR: Boolean = false
 
+	/** Use the old JVM backend */
+	var useOldBackend: Boolean = false
+
 	/** Paths where to find Java 9+ modules */
 	var javaModulePath: Path? = null
 
@@ -313,6 +316,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 		args.jvmTarget = jvmTarget
 		args.javaParameters = javaParameters
 		args.useIR = useIR
+		args.useOldBackend = useOldBackend
 
 		if(javaModulePath != null)
 			args.javaModulePath = javaModulePath!!.toString()


### PR DESCRIPTION
That flag needs to be set to true with Kotlin 1.5.0 in order to use the old backend. The `useIr` property became a no-op.

See also: https://github.com/JetBrains/kotlin/blob/1.5.0-M1/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/jvmArguments.kt#L195-L200