### PR TITLE
Update KSP to alpha08 and adopt new ProcessorProvider API

### DIFF
--- a/ksp/build.gradle
+++ b/ksp/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.ksp_version='1.4.32-1.0.0-alpha07'
+    ext.ksp_version='1.4.32-1.0.0-alpha08'
 }
 
 dependencies {

--- a/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
+++ b/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
@@ -6,7 +6,7 @@ package com.tschuchort.compiletesting
 import com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension
 import com.google.devtools.ksp.KspOptions
 import com.google.devtools.ksp.processing.KSPLogger
-import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.google.devtools.ksp.processing.impl.MessageCollectorBasedKSPLogger
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
@@ -23,11 +23,11 @@ import java.io.File
  * The list of symbol processors for the kotlin compilation.
  * https://goo.gle/ksp
  */
-var KotlinCompilation.symbolProcessors: List<SymbolProcessor>
-    get() = getKspRegistrar().processors
+var KotlinCompilation.symbolProcessorProviders: List<SymbolProcessorProvider>
+    get() = getKspRegistrar().providers
     set(value) {
         val registrar = getKspRegistrar()
-        registrar.processors = value
+        registrar.providers = value
     }
 
 /**
@@ -102,16 +102,16 @@ private val KotlinCompilation.kspCachesDir: File
  */
 private class KspTestExtension(
     options: KspOptions,
-    processors: List<SymbolProcessor>,
+    processorProviders: List<SymbolProcessorProvider>,
     logger: KSPLogger
 ) : AbstractKotlinSymbolProcessingExtension(
     options = options,
     logger = logger,
     testMode = false
 ) {
-    private val loadedProcessors = processors
+    private val loadedProviders = processorProviders
 
-    override fun loadProcessors() = loadedProcessors
+    override fun loadProviders() = loadedProviders
 }
 
 /**
@@ -120,7 +120,7 @@ private class KspTestExtension(
 private class KspCompileTestingComponentRegistrar(
     private val compilation: KotlinCompilation
 ) : ComponentRegistrar {
-    var processors = emptyList<SymbolProcessor>()
+    var providers = emptyList<SymbolProcessorProvider>()
 
     var options: MutableMap<String, String> = mutableMapOf()
 
@@ -128,7 +128,7 @@ private class KspCompileTestingComponentRegistrar(
     var incrementalLog: Boolean = false
 
     override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {
-        if (processors.isEmpty()) {
+        if (providers.isEmpty()) {
             return
         }
         val options = KspOptions.Builder().apply {
@@ -180,7 +180,7 @@ private class KspCompileTestingComponentRegistrar(
                 compilation.verbose
             )
         )
-        val registrar = KspTestExtension(options, processors, messageCollectorBasedKSPLogger)
+        val registrar = KspTestExtension(options, providers, messageCollectorBasedKSPLogger)
         AnalysisHandlerExtension.registerExtension(project, registrar)
     }
 }

--- a/ksp/src/test/kotlin/com/tschuchort/compiletesting/AbstractTestSymbolProcessor.kt
+++ b/ksp/src/test/kotlin/com/tschuchort/compiletesting/AbstractTestSymbolProcessor.kt
@@ -1,24 +1,36 @@
 package com.tschuchort.compiletesting
 
-import com.google.devtools.ksp.processing.CodeGenerator
-import com.google.devtools.ksp.processing.KSPLogger
-import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.KSAnnotated
 
 /**
  * Helper class to write tests, only used in Ksp Compile Testing tests, not a public API.
  */
-internal open class AbstractTestSymbolProcessor : SymbolProcessor {
-    protected lateinit var codeGenerator: CodeGenerator
-    protected lateinit var logger: KSPLogger
-
-    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
-        this.codeGenerator = codeGenerator
-        this.logger = logger
-    }
-
+internal open class AbstractTestSymbolProcessor(
+    protected val codeGenerator: CodeGenerator
+) : SymbolProcessor {
     override fun process(resolver: Resolver): List<KSAnnotated> {
         return emptyList()
+    }
+}
+
+// Would be nice if SymbolProcessorProvider was a fun interface
+internal fun processorProviderOf(
+    body: (
+        options: Map<String, String>,
+        kotlinVersion: KotlinVersion,
+        codeGenerator: CodeGenerator,
+        logger: KSPLogger
+    ) -> SymbolProcessor
+): SymbolProcessorProvider {
+    return object : SymbolProcessorProvider {
+        override fun create(
+            options: Map<String, String>,
+            kotlinVersion: KotlinVersion,
+            codeGenerator: CodeGenerator,
+            logger: KSPLogger
+        ): SymbolProcessor {
+            return body(options, kotlinVersion, codeGenerator, logger)
+        }
     }
 }


### PR DESCRIPTION
KSP alpha08 introduces a new `SymbolProcessorProvider` API to allow for creating immutable/stateless processors. This updates the KSP APIs to this new pattern, as the old `init()`-based pattern is deprecated and will eventually be removed.