### PR TITLE
Update README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Add dependency to your module's `build.gradle` file:
 ```Groovy
 dependencies {
         // ...
-	implementation 'com.github.tschuchortdev:kotlin-compile-testing:1.4.0'
+	testImplementation 'com.github.tschuchortdev:kotlin-compile-testing:1.4.0'
 }
 ```
 
@@ -118,7 +118,7 @@ To test KSP processors, you need to use the KSP dependency:
 
 ```Groovy
 dependencies {
-    implementation 'com.github.tschuchortdev:kotlin-compile-testing-ksp:1.4.0'
+    testImplementation 'com.github.tschuchortdev:kotlin-compile-testing-ksp:1.4.0'
 }
 ```
 


### PR DESCRIPTION
Change installation instructions from `implementation` to the `testImplementation`.