### PR TITLE
Fix JDK 16+ recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,17 +174,17 @@ To mitigate this problem, you have to add the following code to your module's `b
 if (JavaVersion.current() >= JavaVersion.VERSION_16) {
     test {
         jvmArgs(
-	  "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-	  "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-	  "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-	  "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-	  "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
-	  "--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-	  "--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-	  "--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-	  "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-	  "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-	)
+          "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        )
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -173,17 +173,18 @@ To mitigate this problem, you have to add the following code to your module's `b
 ```
 if (JavaVersion.current() >= JavaVersion.VERSION_16) {
     test {
-        jvmArgs = [
-            "--illegal-access=permit",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"
-        ]
+        jvmArgs(
+	  "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+	  "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+	  "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+	  "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+	  "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+	  "--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+	  "--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+	  "--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+	  "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+	  "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+	)
     }
 }
 ```


### PR DESCRIPTION
illegal-access argument will not work in JDK 17 or higher and result in an error, this also adds missing `parser` and `code` subpackages