### PR TITLE
Include the classpaths in the Result.classLoader to be able to load classes from dependencies.

### DIFF
--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -681,3 +681,15 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 		const val OPTION_KAPT_KOTLIN_GENERATED = "kapt.kotlin.generated"
     }
 }
+
+/**
+ * Adds the output directory of [previousResult] to the classpath of this compilation. This is a convenience for
+ * ```
+ * this.classpaths += previousResult.outputDirectory
+ * ```
+ */
+fun KotlinCompilation.addPreviousResultToClasspath(
+	previousResult: KotlinCompilation.Result
+): KotlinCompilation = apply {
+	classpaths += previousResult.outputDirectory
+}

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -259,8 +259,11 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 		val messages: String
 	) {
 		/** class loader to load the compile classes */
-		val classLoader = URLClassLoader(arrayOf(outputDirectory.toURI().toURL()),
-			this::class.java.classLoader)
+		val classLoader = URLClassLoader(
+			// Include the original classpaths and the output directory to be able to load classes from dependencies.
+			classpaths.plus(outputDirectory).map { it.toURI().toURL() }.toTypedArray(),
+			this::class.java.classLoader
+		)
 
 		/** The directory where only the final output class and resources files will be */
 		val outputDirectory: File get() = classesDir

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
@@ -894,8 +894,8 @@ class KotlinCompilationTests {
 			.apply {
 				sources = listOf(kSource2)
 				inheritClassPath = true
-				classpaths += result.outputDirectory
 			}
+			.addPreviousResultToClasspath(result)
 			.compile()
 			.apply {
 				assertThat(exitCode).isEqualTo(ExitCode.OK)


### PR DESCRIPTION
See #216