### PR TITLE
Update to Kotlin 1.6 and KSP 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Kotlin-Compile-Testing is compatible with all _local_ compiler versions. It does
 
 However, if your project or any of its dependencies depend directly on compiler artifacts such as `kotlin-compiler-embeddable` or `kotlin-annotation-processing-embeddable` then they have to be the same version as the one used by Kotlin-Compile-Testing or there will be a transitive dependency conflict.
 
-- Current `kotlin-compiler-embeddable` version: `1.5.31`
+- Current `kotlin-compiler-embeddable` version: `1.6.0`
 
 Because the internal APIs of the Kotlin compiler often change between versions, we can only support one `kotlin-compiler-embeddable` version at a time. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.6.0'
 
     repositories {
         mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 #Tue, 05 Oct 2021 11:53:15 +0000
 kotlin.code.style=official
 kotlin.incremental=false
+kapt.include.compile.classpath=false
 
 GROUP=com.github.tschuchortdev
 VERSION_NAME=1.4.6-SNAPSHOT

--- a/ksp/build.gradle
+++ b/ksp/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.ksp_version='1.5.31-1.0.0'
+    ext.ksp_version='1.5.31-1.0.1'
 }
 
 dependencies {

--- a/ksp/build.gradle
+++ b/ksp/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.ksp_version='1.5.31-1.0.1'
+    ext.ksp_version='1.6.0-1.0.1'
 }
 
 dependencies {

--- a/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
+++ b/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
@@ -72,7 +72,7 @@ var KotlinCompilation.kspIncrementalLog: Boolean
 /**
  * Controls for enabling all warnings as errors in KSP.
  */
-var KotlinCompilation.allWarningsAsErrors: Boolean
+var KotlinCompilation.kspAllWarningsAsErrors: Boolean
     get() = getKspRegistrar().allWarningsAsErrors
     set(value) {
         val registrar = getKspRegistrar()

--- a/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
+++ b/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
@@ -69,6 +69,16 @@ var KotlinCompilation.kspIncrementalLog: Boolean
         registrar.incrementalLog = value
     }
 
+/**
+ * Controls for enabling all warnings as errors in KSP.
+ */
+var KotlinCompilation.allWarningsAsErrors: Boolean
+    get() = getKspRegistrar().allWarningsAsErrors
+    set(value) {
+        val registrar = getKspRegistrar()
+        registrar.allWarningsAsErrors = value
+    }
+
 private val KotlinCompilation.kspJavaSourceDir: File
     get() = kspSourcesDir.resolve("java")
 
@@ -129,6 +139,7 @@ private class KspCompileTestingComponentRegistrar(
 
     var incremental: Boolean = false
     var incrementalLog: Boolean = false
+    var allWarningsAsErrors: Boolean = false
 
     override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {
         if (providers.isEmpty()) {
@@ -141,6 +152,7 @@ private class KspCompileTestingComponentRegistrar(
 
             this.incremental = this@KspCompileTestingComponentRegistrar.incremental
             this.incrementalLog = this@KspCompileTestingComponentRegistrar.incrementalLog
+            this.allWarningsAsErrors = this@KspCompileTestingComponentRegistrar.allWarningsAsErrors
 
             this.cachesDir = compilation.kspCachesDir.also {
                 it.deleteRecursively()
@@ -181,7 +193,8 @@ private class KspCompileTestingComponentRegistrar(
                 compilation.internalMessageStreamAccess,
                 MessageRenderer.GRADLE_STYLE,
                 compilation.verbose
-            )
+            ),
+            allWarningsAsErrors
         )
         val registrar = KspTestExtension(options, providers, messageCollectorBasedKSPLogger)
         AnalysisHandlerExtension.registerExtension(project, registrar)


### PR DESCRIPTION
Resolves #222 along the way and adds support for KSP's new `allWarningsAsError` mode