### PR TITLE
Don't set strictJavaNullabilityAssertions unless requested

### DIFF
--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -92,7 +92,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	var noParamAssertions: Boolean = false
 
 	/** Generate nullability assertions for non-null Java expressions */
-	var strictJavaNullabilityAssertions: Boolean = false
+	var strictJavaNullabilityAssertions: Boolean? = null
 
 	/** Disable optimizations */
 	var noOptimize: Boolean = false
@@ -328,7 +328,9 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 		args.noCallAssertions = noCallAssertions
 		args.noParamAssertions = noParamAssertions
 		args.noReceiverAssertions = noReceiverAssertions
-		args.strictJavaNullabilityAssertions = strictJavaNullabilityAssertions
+                strictJavaNullabilityAssertions?.let {
+                    args.strictJavaNullabilityAssertions = it
+		}
 		args.noOptimize = noOptimize
 
 		if(constructorCallNormalizationMode != null)


### PR DESCRIPTION
This API is actually removed in Kotlin 1.6.20 and normally configured via freeCompilerArg. This makes testing Kotlin 1.6.20 easier