### PR TITLE
Support K2 compiler + make kotlin-stdlib a compileOnly dep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
-    ext.embedded_kotlin_version =  '1.7.10'
+    ext.kotlin_version = '1.7.20-Beta'
+    ext.embedded_kotlin_version = '1.7.20-Beta'
 
     repositories {
         mavenCentral()

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -16,12 +16,14 @@ buildConfig {
 }
 
 dependencies {
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$embedded_kotlin_version"
     compileOnly "com.google.auto.service:auto-service:1.0.1"
     kapt "com.google.auto.service:auto-service:1.0.1"
 
 
     testImplementation 'com.squareup:kotlinpoet:1.12.0'
     testImplementation 'com.squareup:javapoet:1.13.0'
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$embedded_kotlin_version"
 
     implementation "com.squareup.okio:okio:3.2.0"
     implementation 'io.github.classgraph:classgraph:4.8.149'

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
@@ -195,16 +195,7 @@ abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal c
                 } else {
                     emptyList()
                 }
-            args.pluginClasspaths = (args.pluginClasspaths ?: emptyArray()) +
-                    /** The resources path contains the MainComponentRegistrar and MainCommandLineProcessor which will
-                     be found by the Kotlin compiler's service loader. We add it only when the user has actually given
-                     us ComponentRegistrar instances to be loaded by the MainComponentRegistrar because the experimental
-                     K2 compiler doesn't support plugins yet. This way, users of K2 can prevent MainComponentRegistrar
-                     from being loaded and crashing K2 by setting both [compilerPlugins] and [commandLineProcessors] to
-                     the emptyList. */
-                    if (compilerPlugins.isNotEmpty() || commandLineProcessors.isNotEmpty())
-                        arrayOf(getResourcesPath())
-                    else emptyArray()
+            args.pluginClasspaths = (args.pluginClasspaths ?: emptyArray()) + arrayOf(getResourcesPath())
         }
 
         val compilerMessageCollector = PrintingMessageCollector(

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/MainComponentRegistrar.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/MainComponentRegistrar.kt
@@ -26,6 +26,9 @@ import org.jetbrains.kotlin.kapt3.base.incremental.IncrementalProcessor
 @AutoService(ComponentRegistrar::class)
 internal class MainComponentRegistrar : ComponentRegistrar {
 
+    override val supportsK2: Boolean
+        get() = true
+
     override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {
         val parameters = threadLocalParameters.get()
 
@@ -40,6 +43,7 @@ internal class MainComponentRegistrar : ComponentRegistrar {
             componentRegistrar.registerProjectComponents(project,configuration)
         }
 
+        // Will no-op if `parameters.processors` is empty
         KaptComponentRegistrar(parameters.processors, parameters.kaptOptions)
                 .registerProjectComponents(project,configuration)
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,9 @@ kotlin.code.style=official
 kotlin.incremental=false
 kapt.include.compile.classpath=false
 
+# Kotlin adds the stdlib dep by default in 1.4.0+, but we don't want to force our version on consumers.
+kotlin.stdlib.default.dependency=false
+
 GROUP=com.github.tschuchortdev
 VERSION_NAME=1.4.10-SNAPSHOT
 POM_DESCRIPTION=A library that enables testing of Kotlin annotation processors, compiler plugins and code generation.

--- a/ksp/build.gradle
+++ b/ksp/build.gradle
@@ -1,9 +1,12 @@
 buildscript {
-    ext.ksp_version='1.7.10-1.0.6'
+    ext.ksp_version='1.7.20-Beta-1.0.6'
 }
 
 dependencies {
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$embedded_kotlin_version"
     api project(':core')
-    api "com.google.devtools.ksp:symbol-processing-api:$ksp_version"
+    compileOnly "com.google.devtools.ksp:symbol-processing-api:$ksp_version"
     implementation "com.google.devtools.ksp:symbol-processing:$ksp_version"
+    testImplementation "com.google.devtools.ksp:symbol-processing-api:$ksp_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$embedded_kotlin_version"
 }


### PR DESCRIPTION
This allows easily compiling against newer APIs (as needed) and makes the MainComponentRegistrar support K2.

I do think that this library should instead choose to adopt a versioning model like KSP or anvil, where versioning is tied to the Kotlin version it's built against. This way you could release something like `1.4.9-1.7.20-Beta` to make it explicit what is supported, as backward compatibility doesn't provide much value since this uses unstable APIs anyway