### PR TITLE
Remove setting singleModule on compilation args in KotlinCompilation.kt

### DIFF
--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -356,8 +356,6 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 		if(declarationsOutputPath != null)
 			args.declarationsOutputPath = declarationsOutputPath!!.toString()
 
-		args.singleModule = singleModule
-
 		if(javacArguments.isNotEmpty())
 			args.javacArguments = javacArguments.toTypedArray()
 


### PR DESCRIPTION
singleModule was removed from K2JVMCompilerArguments in https://github.com/JetBrains/kotlin/commit/a76de140265a4fdd03fb9c7b642a9cdef7c9c179

As a result setting singleModule will result in a NoSuchMethodError. This fixes it